### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/InfernalRobotics.version
+++ b/InfernalRobotics.version
@@ -1,0 +1,14 @@
+{
+  "NAME": "Infernal Robots",
+  "URL": "https://raw.githubusercontent.com/sirkut/InfernalRobotics/master/InfernalRobots.version",
+  "VERSION": {
+    "MAJOR": 0,
+    "MINOR": 12,
+    "PATCH": "RC1"
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}


### PR DESCRIPTION
Dearest IR authors/maintainers,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)

**Note**: I wasn't sure where to put this, I'm guessing you have a build process. I would be happy to make amendments to that process if you give me pointers in that direction. This file needs to be accessible online as well as somewhere in the GameData folder. Thank you!
