### PR TITLE
Adding GUI Locking in Editor scenes - Feature/editorinputlocking

### DIFF
--- a/InfernalRobotics/InfernalRobotics/GUI.cs
+++ b/InfernalRobotics/InfernalRobotics/GUI.cs
@@ -335,6 +335,7 @@ namespace MuMech
                 IRMinimizeButton.Destroy();
                 IRMinimizeGroupButton.Destroy();
             }
+            EditorLock(false);          ///ensure we remove the lock if it was active
             saveConfigXML();
         }
 
@@ -994,9 +995,42 @@ namespace MuMech
                                                      GUILayout.Height(80));
                 }
 
+                EditorLock(gui.enabled && editorWinPos.Contains(new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y)));
             }
 
             GUIDragAndDrop.OnGUIEvery();
+        }
+
+        /// <summary>
+        /// Applies or removes the lock
+        /// </summary>
+        /// <param name="Apply">Which way are we going</param>
+        internal void EditorLock(Boolean Apply)
+        {
+            //only do this lock in the editor - no point elsewhere
+            if (HighLogic.LoadedSceneIsEditor && Apply)
+            {
+                //only add a new lock if there isnt already one there
+                if (!(InputLockManager.GetControlLock("IRGUILockOfEditor") == ControlTypes.EDITOR_LOCK))
+                {
+#if DEBUG
+                    Debug.Log(String.Format("[IR GUI] AddingLock-{0}", "IRGUILockOfEditor"));
+#endif
+                    InputLockManager.SetControlLock(ControlTypes.EDITOR_LOCK, "IRGUILockOfEditor");
+                }
+            }
+            //Otherwise make sure the lock is removed
+            else
+            {
+                //Only try and remove it if there was one there in the first place
+                if (InputLockManager.GetControlLock("IRGUILockOfEditor") == ControlTypes.EDITOR_LOCK)
+                {
+#if DEBUG
+                    Debug.Log(String.Format("[IR GUI] Removing-{0}", "IRGUILockOfEditor"));
+#endif
+                    InputLockManager.RemoveControlLock("IRGUILockOfEditor");
+                }
+            }
         }
 
         public void loadConfigXML()

--- a/InfernalRobotics/InfernalRobotics/InfernalRobotics.csproj
+++ b/InfernalRobotics/InfernalRobotics/InfernalRobotics.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GUI.cs" />
+    <Compile Include="GUIDragAndDrop.cs" />
     <Compile Include="IRRescale.cs" />
     <Compile Include="MuUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Added a small routine to add a control lock to the editor when the mouse is over the IR window.

This means that if you release the mouse over a part in the vessel it doesnt pick up the part and disassemble your vessel
