### PR TITLE
Fix for GUI Locking in Editor scenes - Feature/editorinputlocking

### DIFF
--- a/InfernalRobotics/InfernalRobotics/GUI.cs
+++ b/InfernalRobotics/InfernalRobotics/GUI.cs
@@ -995,7 +995,7 @@ namespace MuMech
                                                      GUILayout.Height(80));
                 }
 
-                EditorLock(gui.enabled && editorWinPos.Contains(new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y)));
+                EditorLock(guiEnabled && editorWinPos.Contains(new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y)));
             }
 
             GUIDragAndDrop.OnGUIEvery();


### PR DESCRIPTION
I made a typo in the check for whether the window was open - gui.enabled instead of guiEnabled.

This pull request fixes that
