### PR TITLE
added EC consumption

### DIFF
--- a/InfernalRobotics/InfernalRobotics/GUI.cs
+++ b/InfernalRobotics/InfernalRobotics/GUI.cs
@@ -960,6 +960,7 @@ namespace MuMech
                 {
                     updateGroupECRequirement(servoGroup);
                 }
+                initialGroupECUpdate = true;
             }
 
             if (controlWinPos.x == 0 && controlWinPos.y == 0)

--- a/InfernalRobotics/InfernalRobotics/GUI.cs
+++ b/InfernalRobotics/InfernalRobotics/GUI.cs
@@ -58,6 +58,7 @@ namespace MuMech
         protected static MuMechGUI gui_controller;
         bool guiEnabled = false;
         private static bool initialGroupECUpdate;
+        protected static bool useEC = true;
 
 
         #region UITweaks
@@ -89,8 +90,11 @@ namespace MuMech
             servo.forwardKey = to.forwardKey;
             servo.reverseKey = to.reverseKey;
 
-            updateGroupECRequirement(from);
-            updateGroupECRequirement(to);
+            if (useEC)
+            {
+                updateGroupECRequirement(from);
+                updateGroupECRequirement(to);
+            }
         }
 
         public static void add_servo(MuMechToggle servo)
@@ -119,7 +123,10 @@ namespace MuMech
                 if (group == null)
                 {
                     var newGroup = new Group(servo);
-                    updateGroupECRequirement(newGroup);
+                    if (useEC)
+                    {
+                        updateGroupECRequirement(newGroup);
+                    }
                     gui.servo_groups.Add(newGroup);
                     return;
                 }
@@ -138,7 +145,10 @@ namespace MuMech
             servo.forwardKey = group.forwardKey;
             servo.reverseKey = group.reverseKey;
 
-            updateGroupECRequirement(group);
+            if (useEC)
+            {
+                updateGroupECRequirement(group);
+            }
         }
 
         public static void remove_servo(MuMechToggle servo)
@@ -154,7 +164,10 @@ namespace MuMech
                 {
                     group.servos.Remove(servo);
 
-                    updateGroupECRequirement(group);
+                    if (useEC)
+                    {
+                        updateGroupECRequirement(group);
+                    }
                 }
                 num += group.servos.Count;
             }
@@ -210,9 +223,12 @@ namespace MuMech
                     IRMinimizeGroupButton.Visible = true;
                 }
 
-                foreach (var servoGroup in servo_groups)
+                if (useEC)
                 {
-                    updateGroupECRequirement(servoGroup);
+                    foreach (var servoGroup in servo_groups)
+                    {
+                        updateGroupECRequirement(servoGroup);
+                    }
                 }
             }
 
@@ -497,10 +513,13 @@ namespace MuMech
                 }
                 GUILayout.EndHorizontal();
 
-                GUILayout.BeginHorizontal();
-                GUILayout.Space(20);
-                GUILayout.Label(string.Format("Group requires {0:#0.##}EC/s", grp.groupTotalECRequirement),expand);
-                GUILayout.EndHorizontal();
+                if (useEC)
+                {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Space(20);
+                    GUILayout.Label(string.Format("Group requires {0:#0.##}EC/s", grp.groupTotalECRequirement), expand);
+                    GUILayout.EndHorizontal();
+                }
 
                 GUILayout.BeginHorizontal();
 
@@ -728,10 +747,13 @@ namespace MuMech
                 }
                 GUILayout.EndHorizontal();
 
-                GUILayout.BeginHorizontal();
-                GUILayout.Space(20);
-                GUILayout.Label(string.Format("Group requires {0:#0.##}EC/s", grp.groupTotalECRequirement), expand);
-                GUILayout.EndHorizontal();
+                if (useEC)
+                {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Space(20);
+                    GUILayout.Label(string.Format("Group requires {0:#0.##}EC/s", grp.groupTotalECRequirement), expand);
+                    GUILayout.EndHorizontal();
+                }
 
                 GUILayout.BeginHorizontal();
 
@@ -954,13 +976,16 @@ namespace MuMech
             if (InputLockManager.IsLocked(ControlTypes.LINEAR))
                 return;
 
-            if (!initialGroupECUpdate)
+            if (useEC)
             {
-                foreach (var servoGroup in servo_groups)
+                if (!initialGroupECUpdate)
                 {
-                    updateGroupECRequirement(servoGroup);
+                    foreach (var servoGroup in servo_groups)
+                    {
+                        updateGroupECRequirement(servoGroup);
+                    }
+                    initialGroupECUpdate = true;
                 }
-                initialGroupECUpdate = true;
             }
 
             if (controlWinPos.x == 0 && controlWinPos.y == 0)
@@ -1089,6 +1114,7 @@ namespace MuMech
             tweakWinPos = config.GetValue<Rect>("tweakWinPos");
             controlWinPos = config.GetValue<Rect>("controlWinPos");
             groupEditorWinPos = config.GetValue<Rect>("groupEditorWinPos");
+            useEC = config.GetValue<bool>("useEC");
 
         }
 
@@ -1099,6 +1125,7 @@ namespace MuMech
             config.SetValue("tweakWinPos", tweakWinPos);
             config.SetValue("controlWinPos", controlWinPos);
             config.SetValue("groupEditorWinPos", groupEditorWinPos);
+            config.SetValue("useEC", useEC);
             config.save();
         }
     }

--- a/InfernalRobotics/InfernalRobotics/GUI.cs
+++ b/InfernalRobotics/InfernalRobotics/GUI.cs
@@ -393,6 +393,13 @@ namespace MuMech
                     GUILayout.BeginHorizontal();
                     GUILayout.Label(g.name, GUILayout.ExpandWidth(true));
 
+                    if (useEC)
+                    {
+                        var totalConsumption = g.servos.Sum(servo => Mathf.Abs(servo.LastPowerDraw));
+                        var displayText = string.Format("({0:#0.##} Ec/s)", totalConsumption);
+                        GUILayout.Label(displayText, GUILayout.ExpandWidth(true));
+                    }
+
                     int forceFlags = 0;
                     var width20 = GUILayout.Width(20);
                     var width40 = GUILayout.Width(40);
@@ -517,7 +524,7 @@ namespace MuMech
                 {
                     GUILayout.BeginHorizontal();
                     GUILayout.Space(20);
-                    GUILayout.Label(string.Format("Group requires {0:#0.##}EC/s", grp.groupTotalECRequirement), expand);
+                    GUILayout.Label(string.Format("Estimated Power Draw: {0:#0.##} Ec/s", grp.groupTotalECRequirement), expand);
                     GUILayout.EndHorizontal();
                 }
 
@@ -751,7 +758,7 @@ namespace MuMech
                 {
                     GUILayout.BeginHorizontal();
                     GUILayout.Space(20);
-                    GUILayout.Label(string.Format("Group requires {0:#0.##}EC/s", grp.groupTotalECRequirement), expand);
+                    GUILayout.Label(string.Format("Estimated Power Draw: {0:#0.##} Ec/s", grp.groupTotalECRequirement), expand);
                     GUILayout.EndHorizontal();
                 }
 

--- a/InfernalRobotics/InfernalRobotics/Toggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Toggle.cs
@@ -1285,7 +1285,7 @@ namespace MuMech
                     if (this.ecConstraintData.Available)
                     {
                         this.ElectricStateDisplay = string.Format("active - {2}{0:#0.##}/{1:#0.##}EC/s", this.ecConstraintData.ToConsume, ElectricChargeRequired,
-                                                                  this.ecConstraintData.ToConsume < ElectricChargeRequired ? "low power! " : string.Empty);
+                                                                  this.ecConstraintData.ToConsume < (ElectricChargeRequired * TimeWarp.fixedDeltaTime) ? "low power! " : string.Empty);
                     }
                     else
                     {

--- a/InfernalRobotics/InfernalRobotics/Toggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Toggle.cs
@@ -1284,8 +1284,9 @@ namespace MuMech
                     this.part.RequestResource(ElectricChargeResourceName, this.ecConstraintData.ToConsume);
                     if (this.ecConstraintData.Available)
                     {
-                        this.ElectricStateDisplay = string.Format("active - {2}{0:#0.##}/{1:#0.##}EC/s", this.ecConstraintData.ToConsume, ElectricChargeRequired,
-                                                                  this.ecConstraintData.ToConsume < (ElectricChargeRequired * TimeWarp.fixedDeltaTime) ? "low power! " : string.Empty);
+                        var displayConsume = this.ecConstraintData.ToConsume/TimeWarp.fixedDeltaTime;
+                        var lowPower = Mathf.Abs(ElectricChargeRequired - displayConsume) > Mathf.Abs(ElectricChargeRequired * .001f);
+                        this.ElectricStateDisplay = string.Format("active - {2}{0:#0.##}/{1:#0.##}EC/s", displayConsume, ElectricChargeRequired, lowPower ? "low power! " : string.Empty);
                     }
                     else
                     {


### PR DESCRIPTION
This is the expected behavior:
I added a KSPField (float) ElectricChargeRequired which defaults to 2.5
(more than a light bulb but much less than an electrolysis of water).
If only 1 servo is in a group it consumes the timewarp fraction of that
every fixedUpdate. If there is not enough EC it first starts to slow
down its movement speed (linear). If there is less than 10% of the
required amount it still plays the sound and consumes EC but can’t
overcome the friction and don’t move (via a speed of 0 to break as few
things as possible).
If there are multiple servos per group I considered it strange if only
some of them move because they were processed earlier when some EC was
still available. So I built the whole system on the basis of
servo-groups who all move with the same speed reduction applied or don’t
move at all (at least they don’t move together).
Additionally I added a power consumption display in the action menu and a
total amount for each group in the group edit window to allow for easier
planning.

Sirkut: I changed/added more than I had planned. If you don’t like
something feel free to remove/change. I tried to stick with your style conventions and also did not reformat the file (since my ReSharper is set to a very aggressive refactoring), hope it's understandable.
