### PR TITLE
Fix for uppercase letters as keys breaking assignment

### DIFF
--- a/InfernalRobotics/InfernalRobotics/Toggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Toggle.cs
@@ -88,10 +88,22 @@ namespace MuMech
         public string servoName = "";
         [KSPField(isPersistant = true)]
         public string groupName = "";
+        
         [KSPField(isPersistant = true)]
-        public string forwardKey = "";
+        private string fKey = "";
+        
+        public string forwardKey {
+        	get{ return this.fKey;}
+        	set{ this.fKey = value.ToLower(); }
+        }
+        
         [KSPField(isPersistant = true)]
-        public string reverseKey = "";
+        private string rKey = "";
+        
+        public string reverseKey {
+        	get{ return this.rKey;}
+        	set{ this.rKey = value.ToLower(); }
+        }
 
         [KSPField(isPersistant = false)]
         public string onKey = "p";


### PR DESCRIPTION
As the title says, this is a fix for letters not being saved as lowercase, causing a debugspew of unity exceptions.

The fix just adds getters and setters to a different var and even if its attempted to be saved as uppercase, it'll get thrown to lowercase.
