### PR TITLE
Consider adding "Move +" and "Move -" KSPEvents for better KOS integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
-

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
-InfernalRobotics/InfernalRobotics/InfernalRobotics.csproj
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+InfernalRobotics/InfernalRobotics/InfernalRobotics.csproj

--- a/InfernalRobotics/InfernalRobotics/Toggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Toggle.cs
@@ -1549,31 +1549,30 @@ namespace MuMech
         }
 		//add Move+ and Move- KSPEvents as an alternative to corresponding KSPActions
 
-		[KSPEvent(guiName = "Move +", guiActive = true, guiActiveEditor=false)]
-		public void MovePlusEvent()
-		{
-			if ((moveFlags & 0x101) == 0) {
-				this.Events ["MovePlusEvent"].guiName = "Stop Move +";
-				moveFlags |= 0x100;
+        [KSPEvent(guiName = "Move +", guiActive = true, guiActiveEditor=false)]
+        public void MovePlusEvent()
+        {
+            if ((moveFlags & 0x101) == 0) {
+                this.Events ["MovePlusEvent"].guiName = "Stop Move +";
+                moveFlags |= 0x100;
+            } else {
+                this.Events ["MovePlusEvent"].guiName = "Move +";
+                moveFlags &= ~0x100;
+            }
+        }
 
-			} else {
-				this.Events ["MovePlusEvent"].guiName = "Move +";
-				moveFlags &= ~0x100;
-			}
-		}
+        [KSPEvent(guiName = "Move -", guiActive = true, guiActiveEditor=false)]
+        public void MoveMinusEvent()
+        {
+            if ((moveFlags & 0x202) == 0) {
+                this.Events ["MoveMinusEvent"].guiName = "Stop Move -";
+                moveFlags |= 0x200;
 
-		[KSPEvent(guiName = "Move -", guiActive = true, guiActiveEditor=false)]
-		public void MoveMinusEvent()
-		{
-			if ((moveFlags & 0x202) == 0) {
-				this.Events ["MoveMinusEvent"].guiName = "Stop Move -";
-				moveFlags |= 0x200;
-
-			} else {
-				this.Events ["MoveMinusEvent"].guiName = "Move -";
-				moveFlags &= ~0x200;
-			}
-		}
+            } else {
+                this.Events ["MoveMinusEvent"].guiName = "Move -";
+                moveFlags &= ~0x200;
+            }
+        }
 
         [KSPAction("Move +")]
         public void MovePlusAction(KSPActionParam param)

--- a/InfernalRobotics/InfernalRobotics/Toggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Toggle.cs
@@ -1547,6 +1547,33 @@ namespace MuMech
         {
             SetLock(!isMotionLock);
         }
+		//add Move+ and Move- KSPEvents as an alternative to corresponding KSPActions
+
+		[KSPEvent(guiName = "Move +", guiActive = true, guiActiveEditor=false)]
+		public void MovePlusEvent()
+		{
+			if ((moveFlags & 0x101) == 0) {
+				this.Events ["MovePlusEvent"].guiName = "Stop Move +";
+				moveFlags |= 0x100;
+
+			} else {
+				this.Events ["MovePlusEvent"].guiName = "Move +";
+				moveFlags &= ~0x100;
+			}
+		}
+
+		[KSPEvent(guiName = "Move -", guiActive = true, guiActiveEditor=false)]
+		public void MoveMinusEvent()
+		{
+			if ((moveFlags & 0x202) == 0) {
+				this.Events ["MoveMinusEvent"].guiName = "Stop Move -";
+				moveFlags |= 0x200;
+
+			} else {
+				this.Events ["MoveMinusEvent"].guiName = "Move -";
+				moveFlags &= ~0x200;
+			}
+		}
 
         [KSPAction("Move +")]
         public void MovePlusAction(KSPActionParam param)


### PR DESCRIPTION
Recent KOS career limits changes prohibit use of KSPActions in career mode until VAB/SPH is fully upgraded. In order to provide access to IR part moving through KOS earlier in the career mode I decided to create very simple KSPEvents "Move +" and "Move -" with the same functionality as the corresponding KSPActions.
